### PR TITLE
chore: use stable jackson-databind version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.6.3'
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.20.0-rc1")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.3")
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'


### PR DESCRIPTION
## Summary
- replace jackson-databind 2.20.0-rc1 with stable 2.17.3

## Testing
- `./gradlew dependencies` *(fails: Unable to access jarfile /workspace/projeto-DataPrev/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bd3bd85083319e6a23d1160811df