### PR TITLE
Refactor remessa job configuration for property-based output

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/config/RemessaCreditoJobConfig.java
+++ b/src/main/java/br/com/paranabanco/dataprev/config/RemessaCreditoJobConfig.java
@@ -5,6 +5,7 @@ import br.com.paranabanco.dataprev.dto.RemessaCreditoDTO;
 import br.com.paranabanco.dataprev.job.concessao.RemessaConcessaoWriter;
 import br.com.paranabanco.dataprev.job.concessao.RemessaCreditoProcessor;
 import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
@@ -12,25 +13,22 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.database.JpaPagingItemReader;
 import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
+@RequiredArgsConstructor
 public class RemessaCreditoJobConfig {
 
-    @Autowired
-    private JobRepository jobRepository;
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final EntityManagerFactory entityManagerFactory;
+    private final RemessaCreditoProcessor remessaCreditoProcessor;
 
-    @Autowired
-    private PlatformTransactionManager transactionManager;
-
-    @Autowired
-    private EntityManagerFactory entityManagerFactory;
-
-    @Autowired
-    private RemessaCreditoProcessor remessaCreditoProcessor;
+    @Value("${dataprev.remessa.output-dir}")
+    private String remessaOutputDir;
 
     @Bean
     public Job gerarArquivoConcessaoJob() {
@@ -41,7 +39,7 @@ public class RemessaCreditoJobConfig {
 
     @Bean
     public Step gerarRemessaConcessaoStep() {
-        RemessaConcessaoWriter writer = new RemessaConcessaoWriter("build/output");
+        RemessaConcessaoWriter writer = new RemessaConcessaoWriter(remessaOutputDir);
         return new StepBuilder("gerarRemessaConcessaoStep", jobRepository)
                 .<Credito, RemessaCreditoDTO>chunk(100, transactionManager)
                 .reader(concessaoItemReader())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,11 @@ springdoc:
     enabled: true               # /swagger-ui.html
     # path: /swagger-ui.html    # opcional (padrão já é /swagger-ui.html)
 
+
+dataprev:
+  remessa:
+    output-dir: build/output
+
 ---
 # (Opcional) Produção: manter /v3/api-docs para CI e desligar a UI
 spring:


### PR DESCRIPTION
## Summary
- Replace field injection with `@RequiredArgsConstructor` constructor injection in `RemessaCreditoJobConfig`
- Externalize remessa output directory via `dataprev.remessa.output-dir` property and pass it to `RemessaConcessaoWriter`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68a7bd178c2483318402043bd5a3b234