### PR TITLE
Handle null orgao pagador and INSS agency in layout builder

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/job/concessao/RemessaConcessaoLayoutBuilder.java
+++ b/src/main/java/br/com/paranabanco/dataprev/job/concessao/RemessaConcessaoLayoutBuilder.java
@@ -34,7 +34,14 @@ public final class RemessaConcessaoLayoutBuilder {
                 StringUtils.rightPad(credito.getInicioPeriodo().format(DATE_FORMATTER_AAAAMMDD), 8) +
                 StringUtils.leftPad(credito.getNaturezaCredito(), 2, '0') +
                 StringUtils.rightPad(credito.getDataMovimentoCredito().format(DATE_FORMATTER_AAAAMMDD), 8) +
-                StringUtils.leftPad(credito.getOrgaoPagador().getCodigoOrgaoPagador(), 6, '0') +
+                StringUtils.leftPad(
+                        Objects.toString(
+                                credito.getOrgaoPagador() == null ? null : credito.getOrgaoPagador().getCodigoOrgaoPagador(),
+                                ""
+                        ),
+                        6,
+                        '0'
+                ) +
                 formatDecimal(credito.getValorLiquidoCredito(), 10, 2);
         return StringUtils.rightPad(sb, 480);
     }
@@ -56,7 +63,14 @@ public final class RemessaConcessaoLayoutBuilder {
                 StringUtils.leftPad(beneficio.getNumeroBeneficio(), 10) +
                 StringUtils.leftPad(beneficio.getOrgaoPagador().getCodigoOrgaoPagador(), 6, '0') +
                 StringUtils.leftPad("41", 3, '0') +
-                StringUtils.leftPad(beneficio.getAgenciaInss().getCodigoAgencia(), 8, '0') +
+                StringUtils.leftPad(
+                        Objects.toString(
+                                beneficio.getAgenciaInss() == null ? null : beneficio.getAgenciaInss().getCodigoAgencia(),
+                                ""
+                        ),
+                        8,
+                        '0'
+                ) +
                 (beneficio.isInConcJudSemCpf() ? "1" : "0");
         return StringUtils.rightPad(sb, 480);
     }


### PR DESCRIPTION
## Summary
- Prevent NPE by guarding `Credito.origemPagador` access
- Safely handle missing `AgenciaINSS` when building lote 21 details

## Testing
- `gradle test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68a7bd0ea534833187012f6c3e21b656