### PR TITLE
feat: add generic CNAB writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# DataPrev CNAB Writers
+
+O projeto passa a oferecer dois mecanismos para geração de arquivos de remessa:
+
+- **RemessaConcessaoWriter**: implementação original, utilizada diretamente nas etapas do job Spring Batch.
+- **CnabWriter**: nova implementação genérica que utiliza `CnabAssembler` e um layout configurável. O layout
+  padrão `RemessaConcessaoCnabLayout` reutiliza `RemessaConcessaoLayoutBuilder` sem modificá-lo.
+
+## Selecionando o novo writer
+
+Para utilizar o writer genérico, injete o serviço `RemessaCnabWriterService` e forneça uma implementação de
+`CnabLayout`. Exemplo:
+
+```java
+RemessaCnabWriterService service = new RemessaCnabWriterService(new RemessaConcessaoCnabLayout());
+service.write(remessas, Path.of("/tmp/FSUBCON1n.txt"));
+```
+
+Os writers coexistem no projeto; nenhuma alteração foi realizada em `RemessaConcessaoWriter` ou em
+`RemessaConcessaoLayoutBuilder`.

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/assembler/CnabAssembler.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/assembler/CnabAssembler.java
@@ -1,0 +1,21 @@
+package br.com.paranabanco.dataprev.cnab.assembler;
+
+import br.com.paranabanco.dataprev.cnab.layout.CnabLayout;
+
+import java.util.List;
+
+/**
+ * Assembles the list of file lines using a provided {@link CnabLayout} implementation.
+ */
+public class CnabAssembler<T> {
+
+    private final CnabLayout<T> layout;
+
+    public CnabAssembler(CnabLayout<T> layout) {
+        this.layout = layout;
+    }
+
+    public List<String> assemble(List<T> items) {
+        return layout.build(items);
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/layout/CnabLayout.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/layout/CnabLayout.java
@@ -1,0 +1,11 @@
+package br.com.paranabanco.dataprev.cnab.layout;
+
+import java.util.List;
+
+/**
+ * Generic contract for CNAB layouts. Implementations return the list of
+ * formatted lines that compose the file for the given items.
+ */
+public interface CnabLayout<T> {
+    List<String> build(List<T> items);
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/layout/RemessaConcessaoCnabLayout.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/layout/RemessaConcessaoCnabLayout.java
@@ -1,0 +1,52 @@
+package br.com.paranabanco.dataprev.cnab.layout;
+
+import br.com.paranabanco.dataprev.domain.Beneficio;
+import br.com.paranabanco.dataprev.domain.Credito;
+import br.com.paranabanco.dataprev.dto.RemessaCreditoDTO;
+import br.com.paranabanco.dataprev.job.concessao.RemessaConcessaoLayoutBuilder;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * CNAB layout implementation that delegates to {@link RemessaConcessaoLayoutBuilder}.
+ * This allows the new {@code CnabWriter} to reuse the existing layout logic without
+ * modifying the legacy builder.
+ */
+public class RemessaConcessaoCnabLayout implements CnabLayout<RemessaCreditoDTO> {
+
+    @Override
+    public List<String> build(List<RemessaCreditoDTO> remessas) {
+        List<String> lines = new ArrayList<>();
+
+        // --- LOTE 20 ---
+        lines.add(RemessaConcessaoLayoutBuilder.buildHeaderLote20e21("20", "01"));
+        BigDecimal totalValorLote20 = BigDecimal.ZERO;
+        for (RemessaCreditoDTO dto : remessas) {
+            Credito credito = dto.getCredito();
+            lines.add(RemessaConcessaoLayoutBuilder.buildDetalheLote20(credito));
+            totalValorLote20 = totalValorLote20.add(
+                    Optional.ofNullable(credito.getValorLiquidoCredito()).orElse(BigDecimal.ZERO)
+            );
+        }
+        lines.add(RemessaConcessaoLayoutBuilder.buildTrailerLote20(remessas.size(), totalValorLote20));
+
+        // --- LOTE 21 ---
+        Map<String, Beneficio> uniqueBeneficios = new LinkedHashMap<>();
+        for (RemessaCreditoDTO dto : remessas) {
+            Credito credito = dto.getCredito();
+            uniqueBeneficios.put(credito.getBeneficio().getNumeroBeneficio(), credito.getBeneficio());
+        }
+        lines.add(RemessaConcessaoLayoutBuilder.buildHeaderLote20e21("21", "01"));
+        for (Beneficio beneficio : uniqueBeneficios.values()) {
+            lines.add(RemessaConcessaoLayoutBuilder.buildDetalheLote21(beneficio));
+        }
+        lines.add(RemessaConcessaoLayoutBuilder.buildTrailerLote21(uniqueBeneficios.size()));
+
+        return lines;
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/write/CnabWriter.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/write/CnabWriter.java
@@ -1,0 +1,33 @@
+package br.com.paranabanco.dataprev.cnab.write;
+
+import br.com.paranabanco.dataprev.cnab.assembler.CnabAssembler;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Generic writer that persists the lines produced by a {@link CnabAssembler}
+ * into a file.
+ */
+public class CnabWriter<T> {
+
+    private final CnabAssembler<T> assembler;
+
+    public CnabWriter(CnabAssembler<T> assembler) {
+        this.assembler = assembler;
+    }
+
+    public void write(List<T> items, Path file) throws IOException {
+        Files.createDirectories(file.getParent());
+        List<String> lines = assembler.assemble(items);
+        try (BufferedWriter writer = Files.newBufferedWriter(file)) {
+            for (String line : lines) {
+                writer.write(line);
+                writer.newLine();
+            }
+        }
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/write/RemessaCnabWriterService.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/write/RemessaCnabWriterService.java
@@ -1,0 +1,29 @@
+package br.com.paranabanco.dataprev.cnab.write;
+
+import br.com.paranabanco.dataprev.cnab.assembler.CnabAssembler;
+import br.com.paranabanco.dataprev.cnab.layout.CnabLayout;
+import br.com.paranabanco.dataprev.dto.RemessaCreditoDTO;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Facade service that exposes the {@link CnabWriter} for writing remessa files.
+ * Existing components remain untouched; this service provides an alternative
+ * entry point for clients that want to use the new generic writer.
+ */
+@Service
+public class RemessaCnabWriterService {
+
+    private final CnabWriter<RemessaCreditoDTO> writer;
+
+    public RemessaCnabWriterService(CnabLayout<RemessaCreditoDTO> layout) {
+        this.writer = new CnabWriter<>(new CnabAssembler<>(layout));
+    }
+
+    public void write(List<RemessaCreditoDTO> remessas, Path file) throws IOException {
+        writer.write(remessas, file);
+    }
+}

--- a/src/test/java/br/com/paranabanco/dataprev/cnab/write/CnabWriterTest.java
+++ b/src/test/java/br/com/paranabanco/dataprev/cnab/write/CnabWriterTest.java
@@ -1,0 +1,61 @@
+package br.com.paranabanco.dataprev.cnab.write;
+
+import br.com.paranabanco.dataprev.cnab.layout.RemessaConcessaoCnabLayout;
+import br.com.paranabanco.dataprev.domain.AgenciaINSS;
+import br.com.paranabanco.dataprev.domain.Banco;
+import br.com.paranabanco.dataprev.domain.Beneficio;
+import br.com.paranabanco.dataprev.domain.Credito;
+import br.com.paranabanco.dataprev.domain.OrgaoPagador;
+import br.com.paranabanco.dataprev.dto.RemessaCreditoDTO;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CnabWriterTest {
+
+    @Test
+    void shouldGenerateFileUsingNewWriter() throws IOException {
+        Banco banco = Banco.builder().codigoBanco("001").nomeBanco("Banco").build();
+        OrgaoPagador orgao = OrgaoPagador.builder().codigoOrgaoPagador("123456").banco(banco).build();
+        AgenciaINSS agencia = AgenciaINSS.builder().codigoAgencia("12345678").nomeAgencia("Agencia").build();
+
+        Beneficio beneficio = Beneficio.builder()
+                .numeroBeneficio("1234567890")
+                .orgaoPagador(orgao)
+                .agenciaInss(agencia)
+                .inConcJudSemCpf(false)
+                .build();
+
+        Credito credito = Credito.builder()
+                .beneficio(beneficio)
+                .fimPeriodo(LocalDate.now())
+                .inicioPeriodo(LocalDate.now().minusDays(30))
+                .naturezaCredito("01")
+                .dataMovimentoCredito(LocalDate.now())
+                .orgaoPagador(orgao)
+                .valorLiquidoCredito(BigDecimal.TEN)
+                .build();
+
+        RemessaCreditoDTO dto = RemessaCreditoDTO.builder().credito(credito).build();
+
+        RemessaCnabWriterService service = new RemessaCnabWriterService(new RemessaConcessaoCnabLayout());
+        Path tempFile = Files.createTempFile("remessa", ".txt");
+        service.write(List.of(dto), tempFile);
+
+        List<String> lines = Files.readAllLines(tempFile);
+        assertEquals(6, lines.size());
+        assertTrue(lines.get(0).startsWith("/"));
+        assertTrue(lines.get(1).startsWith("<"));
+        assertTrue(lines.get(2).startsWith("\\"));
+        assertTrue(lines.get(3).startsWith("/"));
+        assertTrue(lines.get(4).startsWith("<"));
+        assertTrue(lines.get(5).startsWith("\\"));
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable CNAB writer based on CnabAssembler
- expose writer through RemessaCnabWriterService
- document and test new writer alongside legacy implementation

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68a897ced6b08331aa3e889a3df31169