### PR TITLE
Add CNAB reader/writer roundtrip test

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/cnab/CnabReader.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/CnabReader.java
@@ -1,0 +1,32 @@
+package br.com.paranabanco.dataprev.cnab;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Utility class to read CNAB files as lists of records.
+ */
+public class CnabReader {
+
+    private final Path file;
+
+    public CnabReader(Path file) {
+        this.file = file;
+    }
+
+    /**
+     * Reads all records from the configured file.
+     */
+    public List<String> readAll() throws IOException {
+        return Files.readAllLines(file);
+    }
+
+    /**
+     * Convenience static method to read all records from a file.
+     */
+    public static List<String> read(Path file) throws IOException {
+        return Files.readAllLines(file);
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/CnabWriter.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/CnabWriter.java
@@ -1,0 +1,32 @@
+package br.com.paranabanco.dataprev.cnab;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Utility class to write CNAB records to a file.
+ */
+public class CnabWriter {
+
+    private final Path file;
+
+    public CnabWriter(Path file) {
+        this.file = file;
+    }
+
+    /**
+     * Writes the provided records to the configured file.
+     */
+    public void write(List<String> lines) throws IOException {
+        Files.write(file, lines);
+    }
+
+    /**
+     * Convenience static method to write records to a file.
+     */
+    public static void write(Path file, List<String> lines) throws IOException {
+        Files.write(file, lines);
+    }
+}

--- a/src/test/java/br/com/paranabanco/dataprev/cnab/CnabReaderWriterTest.java
+++ b/src/test/java/br/com/paranabanco/dataprev/cnab/CnabReaderWriterTest.java
@@ -1,0 +1,56 @@
+package br.com.paranabanco.dataprev.cnab;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CnabReaderWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void readWriteReadCnabFile() throws IOException {
+        Path originalPath = Paths.get("src", "main", "resources", "HMLCES18.B254.D0000001.txt");
+
+        // Read original records
+        List<String> originalLines = CnabReader.read(originalPath);
+        assertFalse(originalLines.isEmpty(), "Arquivo original deve conter registros");
+        originalLines.forEach(line -> assertEquals(240, line.length(), "Cada registro deve ter tamanho 240"));
+
+        long originalSum = sumDigits(originalLines);
+        int originalCount = originalLines.size();
+
+        // Write to temporary file
+        Path tempFile = tempDir.resolve("cnab-temp.txt");
+        CnabWriter.write(tempFile, originalLines);
+
+        // Read back
+        List<String> rereadLines = CnabReader.read(tempFile);
+        rereadLines.forEach(line -> assertEquals(240, line.length(), "Cada registro deve ter tamanho 240"));
+        assertEquals(originalCount, rereadLines.size(), "Contagem de registros deve ser mantida");
+
+        long rereadSum = sumDigits(rereadLines);
+        assertEquals(originalSum, rereadSum, "Somatório dos dígitos deve ser mantido");
+
+        assertEquals(originalLines, rereadLines, "Conteúdo reescrito deve ser igual ao original");
+    }
+
+    private long sumDigits(List<String> lines) {
+        long sum = 0;
+        for (String line : lines) {
+            for (char c : line.toCharArray()) {
+                if (Character.isDigit(c)) {
+                    sum += c - '0';
+                }
+            }
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
## Summary
- add simple CNAB reader and writer utilities
- verify CNAB sample roundtrips through reader and writer

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68a897c94cfc8331b2418ebae8189ed3