### PR TITLE
Add CNAB utilities for field formatting and numeric parsing

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/cnab/CnabAssembler.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/CnabAssembler.java
@@ -1,0 +1,35 @@
+package br.com.paranabanco.dataprev.cnab;
+
+import br.com.paranabanco.dataprev.cnab.util.FieldFormatters;
+import br.com.paranabanco.dataprev.cnab.util.NumericUtils;
+import java.math.BigDecimal;
+import java.util.Map;
+
+/**
+ * Assembles CNAB records from provided values applying the proper
+ * formatting rules.
+ */
+public class CnabAssembler {
+
+    private final CnabRecordDef definition;
+
+    public CnabAssembler(CnabRecordDef definition) {
+        this.definition = definition;
+    }
+
+    public String assemble(Map<String, Object> values) {
+        StringBuilder sb = new StringBuilder();
+        for (CnabRecordDef.Field f : definition.getFields()) {
+            Object value = values.get(f.name());
+            String formatted;
+            if (f.type() == CnabRecordDef.FieldType.ALPHA) {
+                formatted = FieldFormatters.formatAlphanumeric(value != null ? value.toString() : "", f.length());
+            } else {
+                BigDecimal bd = value == null ? BigDecimal.ZERO : new BigDecimal(value.toString());
+                formatted = NumericUtils.format(bd, f.length(), f.decimals());
+            }
+            sb.append(formatted);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/CnabRecordDef.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/CnabRecordDef.java
@@ -1,0 +1,58 @@
+package br.com.paranabanco.dataprev.cnab;
+
+import br.com.paranabanco.dataprev.cnab.util.FieldFormatters;
+import br.com.paranabanco.dataprev.cnab.util.NumericUtils;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Definition of a CNAB record used for parsing positional files.
+ */
+public class CnabRecordDef {
+
+    private final List<Field> fields;
+
+    public CnabRecordDef(List<Field> fields) {
+        this.fields = fields;
+    }
+
+    public List<Field> getFields() {
+        return fields;
+    }
+
+    /**
+     * Parses a line according to the configured fields applying the adequate
+     * formatters.
+     */
+    public Map<String, Object> parse(String line) {
+        Map<String, Object> values = new HashMap<>();
+        int pos = 0;
+        for (Field f : fields) {
+            int end = Math.min(pos + f.length(), line.length());
+            String raw = line.substring(pos, end);
+            Object value;
+            if (f.type() == FieldType.ALPHA) {
+                value = FieldFormatters.normalize(raw);
+            } else {
+                value = NumericUtils.parse(raw, f.decimals());
+            }
+            values.put(f.name(), value);
+            pos += f.length();
+        }
+        return values;
+    }
+
+    /** Field definition within a record. */
+    public record Field(String name, int length, FieldType type, int decimals) {
+        public Field(String name, int length, FieldType type) {
+            this(name, length, type, 0);
+        }
+    }
+
+    /** Supported field types. */
+    public enum FieldType {
+        ALPHA,
+        NUMERIC
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/util/FieldFormatters.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/util/FieldFormatters.java
@@ -1,0 +1,41 @@
+package br.com.paranabanco.dataprev.cnab.util;
+
+import java.text.Normalizer;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility helpers for formatting CNAB fields.
+ */
+public final class FieldFormatters {
+
+    private FieldFormatters() {}
+
+    /**
+     * Pads the provided value with zeros on the left until the requested length is met.
+     */
+    public static String zeroFill(String value, int length) {
+        String content = value != null ? value : "";
+        return StringUtils.leftPad(content, length, '0');
+    }
+
+    /**
+     * Trims the value, converts to upper case and removes diacritics.
+     */
+    public static String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim().toUpperCase();
+        String normalized = Normalizer.normalize(trimmed, Normalizer.Form.NFD);
+        return normalized.replaceAll("\\p{M}", "");
+    }
+
+    /**
+     * Formats an alphanumeric field applying {@link #normalize(String)} and padding
+     * the result with spaces on the right to match the desired length.
+     */
+    public static String formatAlphanumeric(String value, int length) {
+        String normalized = normalize(value);
+        return StringUtils.rightPad(normalized, length, ' ');
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/util/NumericUtils.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/util/NumericUtils.java
@@ -1,0 +1,40 @@
+package br.com.paranabanco.dataprev.cnab.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utilities for dealing with numeric values in CNAB files.
+ */
+public final class NumericUtils {
+
+    private NumericUtils() {}
+
+    /**
+     * Parses a numeric string that does not contain a decimal separator into a {@link BigDecimal}.
+     *
+     * @param value  the numeric string
+     * @param scale  number of decimal places the value represents
+     * @return the parsed {@link BigDecimal}
+     */
+    public static BigDecimal parse(String value, int scale) {
+        String digits = StringUtils.defaultString(value).trim();
+        if (digits.isEmpty()) {
+            return BigDecimal.ZERO.setScale(scale);
+        }
+        BigInteger integer = new BigInteger(digits);
+        return new BigDecimal(integer, scale);
+    }
+
+    /**
+     * Formats a {@link BigDecimal} value without a decimal separator and zero fills
+     * it to the desired length.
+     */
+    public static String format(BigDecimal value, int length, int scale) {
+        BigDecimal scaled = value.setScale(scale, RoundingMode.HALF_UP);
+        String digits = scaled.movePointRight(scale).toPlainString();
+        return StringUtils.leftPad(digits, length, '0');
+    }
+}

--- a/src/test/java/br/com/paranabanco/dataprev/cnab/CnabIntegrationTest.java
+++ b/src/test/java/br/com/paranabanco/dataprev/cnab/CnabIntegrationTest.java
@@ -1,0 +1,33 @@
+package br.com.paranabanco.dataprev.cnab;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import br.com.paranabanco.dataprev.cnab.CnabRecordDef.Field;
+import br.com.paranabanco.dataprev.cnab.CnabRecordDef.FieldType;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class CnabIntegrationTest {
+
+    @Test
+    void assembleAndParseRecord() {
+        CnabRecordDef def = new CnabRecordDef(List.of(
+                new Field("name", 10, FieldType.ALPHA),
+                new Field("amount", 10, FieldType.NUMERIC, 2)));
+
+        CnabAssembler assembler = new CnabAssembler(def);
+
+        Map<String, Object> values = Map.of(
+                "name", " João ",
+                "amount", new BigDecimal("123.45"));
+
+        String line = assembler.assemble(values);
+        assertEquals("JOAO      0000012345", line);
+
+        Map<String, Object> parsed = def.parse(line);
+        assertEquals("JOAO", parsed.get("name"));
+        assertEquals(new BigDecimal("123.45"), parsed.get("amount"));
+    }
+}

--- a/src/test/java/br/com/paranabanco/dataprev/cnab/util/FieldFormattersTest.java
+++ b/src/test/java/br/com/paranabanco/dataprev/cnab/util/FieldFormattersTest.java
@@ -1,0 +1,19 @@
+package br.com.paranabanco.dataprev.cnab.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class FieldFormattersTest {
+
+    @Test
+    void alphanumericFormattingRemovesDiacriticsAndUppercases() {
+        String formatted = FieldFormatters.formatAlphanumeric(" João ", 10);
+        assertEquals("JOAO      ", formatted);
+    }
+
+    @Test
+    void zeroFillPadsWithZeros() {
+        assertEquals("00123", FieldFormatters.zeroFill("123", 5));
+    }
+}

--- a/src/test/java/br/com/paranabanco/dataprev/cnab/util/NumericUtilsTest.java
+++ b/src/test/java/br/com/paranabanco/dataprev/cnab/util/NumericUtilsTest.java
@@ -1,0 +1,21 @@
+package br.com.paranabanco.dataprev.cnab.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+public class NumericUtilsTest {
+
+    @Test
+    void parseMonetaryValue() {
+        BigDecimal value = NumericUtils.parse("0000012345", 2);
+        assertEquals(new BigDecimal("123.45"), value);
+    }
+
+    @Test
+    void formatMonetaryValue() {
+        String formatted = NumericUtils.format(new BigDecimal("123.45"), 10, 2);
+        assertEquals("0000012345", formatted);
+    }
+}


### PR DESCRIPTION
## Summary
- add FieldFormatters for zero fill, normalization and padding
- introduce NumericUtils to parse and format monetary values without separators
- integrate utilities with CnabRecordDef and CnabAssembler
- add unit tests covering formatting, numeric conversion and end-to-end assembly/parse

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68a897c741748331bb6f4c2abc5508b4