### PR TITLE
Add CNAB domain records with map conversion

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/cnab/domain/HeaderArquivo.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/domain/HeaderArquivo.java
@@ -1,0 +1,27 @@
+package br.com.paranabanco.dataprev.cnab.domain;
+
+import java.util.Map;
+
+/**
+ * Representa o cabeçalho do arquivo CNAB.
+ */
+public record HeaderArquivo(
+        String banco,
+        String dataGeracao
+) {
+    /** Converte a entidade para um mapa. */
+    public Map<String, String> toMap() {
+        return Map.of(
+                "banco", banco,
+                "dataGeracao", dataGeracao
+        );
+    }
+
+    /** Constrói a entidade a partir de um mapa. */
+    public static HeaderArquivo fromMap(Map<String, String> map) {
+        return new HeaderArquivo(
+                map.get("banco"),
+                map.get("dataGeracao")
+        );
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/domain/HeaderLote.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/domain/HeaderLote.java
@@ -1,0 +1,25 @@
+package br.com.paranabanco.dataprev.cnab.domain;
+
+import java.util.Map;
+
+/**
+ * Representa o cabeçalho de um lote CNAB.
+ */
+public record HeaderLote(
+        String banco,
+        String lote
+) {
+    public Map<String, String> toMap() {
+        return Map.of(
+                "banco", banco,
+                "lote", lote
+        );
+    }
+
+    public static HeaderLote fromMap(Map<String, String> map) {
+        return new HeaderLote(
+                map.get("banco"),
+                map.get("lote")
+        );
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/domain/SegmentoA.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/domain/SegmentoA.java
@@ -1,0 +1,28 @@
+package br.com.paranabanco.dataprev.cnab.domain;
+
+import java.util.Map;
+
+/**
+ * Segmento A de um detalhe do arquivo CNAB.
+ */
+public record SegmentoA(
+        String agencia,
+        String conta,
+        String valor
+) {
+    public Map<String, String> toMap() {
+        return Map.of(
+                "agencia", agencia,
+                "conta", conta,
+                "valor", valor
+        );
+    }
+
+    public static SegmentoA fromMap(Map<String, String> map) {
+        return new SegmentoA(
+                map.get("agencia"),
+                map.get("conta"),
+                map.get("valor")
+        );
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/domain/SegmentoB.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/domain/SegmentoB.java
@@ -1,0 +1,25 @@
+package br.com.paranabanco.dataprev.cnab.domain;
+
+import java.util.Map;
+
+/**
+ * Segmento B de um detalhe do arquivo CNAB.
+ */
+public record SegmentoB(
+        String cpf,
+        String endereco
+) {
+    public Map<String, String> toMap() {
+        return Map.of(
+                "cpf", cpf,
+                "endereco", endereco
+        );
+    }
+
+    public static SegmentoB fromMap(Map<String, String> map) {
+        return new SegmentoB(
+                map.get("cpf"),
+                map.get("endereco")
+        );
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/domain/TrailerArquivo.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/domain/TrailerArquivo.java
@@ -1,0 +1,25 @@
+package br.com.paranabanco.dataprev.cnab.domain;
+
+import java.util.Map;
+
+/**
+ * Trailer do arquivo CNAB.
+ */
+public record TrailerArquivo(
+        String quantidadeLotes,
+        String quantidadeRegistros
+) {
+    public Map<String, String> toMap() {
+        return Map.of(
+                "quantidadeLotes", quantidadeLotes,
+                "quantidadeRegistros", quantidadeRegistros
+        );
+    }
+
+    public static TrailerArquivo fromMap(Map<String, String> map) {
+        return new TrailerArquivo(
+                map.get("quantidadeLotes"),
+                map.get("quantidadeRegistros")
+        );
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/domain/TrailerLote.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/domain/TrailerLote.java
@@ -1,0 +1,25 @@
+package br.com.paranabanco.dataprev.cnab.domain;
+
+import java.util.Map;
+
+/**
+ * Trailer de um lote CNAB.
+ */
+public record TrailerLote(
+        String lote,
+        String quantidadeRegistros
+) {
+    public Map<String, String> toMap() {
+        return Map.of(
+                "lote", lote,
+                "quantidadeRegistros", quantidadeRegistros
+        );
+    }
+
+    public static TrailerLote fromMap(Map<String, String> map) {
+        return new TrailerLote(
+                map.get("lote"),
+                map.get("quantidadeRegistros")
+        );
+    }
+}

--- a/src/test/java/br/com/paranabanco/dataprev/cnab/domain/CnabDomainConversionTest.java
+++ b/src/test/java/br/com/paranabanco/dataprev/cnab/domain/CnabDomainConversionTest.java
@@ -1,0 +1,58 @@
+package br.com.paranabanco.dataprev.cnab.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class CnabDomainConversionTest {
+
+    @Test
+    void headerArquivoToFromMap() {
+        HeaderArquivo original = new HeaderArquivo("001", "20240101");
+        Map<String, String> map = original.toMap();
+        HeaderArquivo rebuilt = HeaderArquivo.fromMap(map);
+        assertEquals(original, rebuilt);
+    }
+
+    @Test
+    void headerLoteToFromMap() {
+        HeaderLote original = new HeaderLote("001", "0001");
+        Map<String, String> map = original.toMap();
+        HeaderLote rebuilt = HeaderLote.fromMap(map);
+        assertEquals(original, rebuilt);
+    }
+
+    @Test
+    void segmentoAToFromMap() {
+        SegmentoA original = new SegmentoA("1234", "56789", "1000");
+        Map<String, String> map = original.toMap();
+        SegmentoA rebuilt = SegmentoA.fromMap(map);
+        assertEquals(original, rebuilt);
+    }
+
+    @Test
+    void segmentoBToFromMap() {
+        SegmentoB original = new SegmentoB("12345678900", "Rua A");
+        Map<String, String> map = original.toMap();
+        SegmentoB rebuilt = SegmentoB.fromMap(map);
+        assertEquals(original, rebuilt);
+    }
+
+    @Test
+    void trailerLoteToFromMap() {
+        TrailerLote original = new TrailerLote("0001", "10");
+        Map<String, String> map = original.toMap();
+        TrailerLote rebuilt = TrailerLote.fromMap(map);
+        assertEquals(original, rebuilt);
+    }
+
+    @Test
+    void trailerArquivoToFromMap() {
+        TrailerArquivo original = new TrailerArquivo("5", "50");
+        Map<String, String> map = original.toMap();
+        TrailerArquivo rebuilt = TrailerArquivo.fromMap(map);
+        assertEquals(original, rebuilt);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce CNAB domain records (HeaderArquivo, HeaderLote, SegmentoA, SegmentoB, TrailerLote, TrailerArquivo)
- add `toMap`/`fromMap` helpers to ease integration with assemblers/readers
- cover conversions with unit tests

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68a897c3a5588331949dbd379159dfd5