### PR TITLE
Implement CNAB parsing utilities and tests

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabLayout.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabLayout.java
@@ -1,0 +1,22 @@
+package br.com.paranabanco.dataprev.cnab.parse;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Layout used for matching and parsing CNAB lines.
+ */
+public interface CnabLayout {
+
+    /**
+     * Determines the record type for the given line.
+     *
+     * @return optional record type identifier
+     */
+    Optional<String> matchRecord(CnabLine line);
+
+    /**
+     * Parses the line according to the record type, returning a map of field values.
+     */
+    Map<String, String> parse(String recordType, CnabLine line);
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabLine.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabLine.java
@@ -1,0 +1,28 @@
+package br.com.paranabanco.dataprev.cnab.parse;
+
+import java.util.Objects;
+
+/**
+ * Wrapper for a CNAB line with fixed length of 240 columns.
+ */
+public record CnabLine(String content) {
+
+    public static final int LENGTH = 240;
+
+    public CnabLine {
+        Objects.requireNonNull(content, "content");
+        if (content.length() != LENGTH) {
+            throw new IllegalArgumentException(
+                    "CNAB line must have exactly " + LENGTH + " characters, got " + content.length());
+        }
+    }
+
+    /**
+     * Returns a substring using 1-based positions. End index is inclusive.
+     */
+    public String slice(int start, int end) {
+        int from = Math.max(0, start - 1);
+        int to = Math.min(content.length(), end);
+        return content.substring(from, to);
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabReader.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabReader.java
@@ -1,0 +1,51 @@
+package br.com.paranabanco.dataprev.cnab.parse;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Reads CNAB files producing {@link CnabRecord} instances.
+ */
+public class CnabReader {
+
+    private final CnabLayout layout;
+
+    public CnabReader(CnabLayout layout) {
+        this.layout = layout;
+    }
+
+    public List<CnabRecord> read(Path path) throws IOException {
+        try (BufferedReader br = Files.newBufferedReader(path)) {
+            return read(br);
+        }
+    }
+
+    public List<CnabRecord> read(Reader reader) throws IOException {
+        BufferedReader br = reader instanceof BufferedReader ? (BufferedReader) reader : new BufferedReader(reader);
+        List<CnabRecord> records = new ArrayList<>();
+        String line;
+        int lineNumber = 0;
+        while ((line = br.readLine()) != null) {
+            lineNumber++;
+            if (line.isEmpty()) {
+                continue;
+            }
+            CnabLine cnabLine = new CnabLine(line);
+            Optional<String> typeOpt = layout.matchRecord(cnabLine);
+            if (typeOpt.isEmpty()) {
+                continue;
+            }
+            String type = typeOpt.get();
+            Map<String, String> values = layout.parse(type, cnabLine);
+            records.add(new CnabRecord(type, values, lineNumber));
+        }
+        return records;
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabRecord.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabRecord.java
@@ -1,0 +1,9 @@
+package br.com.paranabanco.dataprev.cnab.parse;
+
+import java.util.Map;
+
+/**
+ * Parsed CNAB record with type, field values and line number.
+ */
+public record CnabRecord(String type, Map<String, String> values, int lineNumber) {
+}

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabValidator.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/parse/CnabValidator.java
@@ -1,0 +1,66 @@
+package br.com.paranabanco.dataprev.cnab.parse;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility methods for validating CNAB files and records.
+ */
+public final class CnabValidator {
+
+    private CnabValidator() {
+    }
+
+    /**
+     * Ensures all lines have the expected 240 characters.
+     */
+    public static void validateLineLength(List<CnabLine> lines) {
+        int index = 1;
+        for (CnabLine line : lines) {
+            if (line.content().length() != CnabLine.LENGTH) {
+                throw new IllegalArgumentException("Linha " + index + " possui tamanho " + line.content().length());
+            }
+            index++;
+        }
+    }
+
+    /**
+     * Validates trailer totals against the provided segments.
+     *
+     * @param segments records representing segments (details)
+     * @param trailers trailer records
+     * @param amountField field name holding amount values
+     * @param countField field name holding record counts
+     */
+    public static void validateTrailerTotals(List<CnabRecord> segments,
+                                             List<CnabRecord> trailers,
+                                             String amountField,
+                                             String countField) {
+        BigDecimal sum = segments.stream()
+                .map(r -> new BigDecimal(r.values().getOrDefault(amountField, "0")))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        int count = segments.size();
+        for (CnabRecord trailer : trailers) {
+            BigDecimal trailerSum = new BigDecimal(trailer.values().getOrDefault(amountField, "0"));
+            int trailerCount = Integer.parseInt(trailer.values().getOrDefault(countField, "0"));
+            if (count != trailerCount || sum.compareTo(trailerSum) != 0) {
+                throw new IllegalStateException("Trailer invalido na linha " + trailer.lineNumber());
+            }
+        }
+    }
+
+    /**
+     * Checks mandatory fields in a record.
+     */
+    public static void requireFields(CnabRecord record, String... fields) {
+        Map<String, String> values = record.values();
+        for (String field : fields) {
+            String value = values.get(field);
+            if (value == null || value.isBlank()) {
+                throw new IllegalArgumentException("Campo obrigatorio ausente: " + field +
+                        " na linha " + record.lineNumber());
+            }
+        }
+    }
+}

--- a/src/test/java/br/com/paranabanco/dataprev/cnab/parse/CnabReaderTest.java
+++ b/src/test/java/br/com/paranabanco/dataprev/cnab/parse/CnabReaderTest.java
@@ -1,0 +1,51 @@
+package br.com.paranabanco.dataprev.cnab.parse;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CnabReaderTest {
+
+    @Test
+    void readFileAndCountRecords() throws IOException {
+        Path path = Path.of("src/main/resources/HMLCES18.B254.D0000001.txt");
+        CnabLayout layout = new SimpleLayout();
+        CnabReader reader = new CnabReader(layout);
+        List<CnabRecord> records = reader.read(path);
+
+        long headers = records.stream().filter(r -> r.type().equals("HEADER")).count();
+        long segments = records.stream().filter(r -> r.type().equals("SEGMENT")).count();
+        long trailers = records.stream().filter(r -> r.type().equals("TRAILER")).count();
+
+        assertEquals(32, headers, "headers");
+        assertEquals(447, segments, "segments");
+        assertEquals(30, trailers, "trailers");
+    }
+
+    /**
+     * Minimal layout used for tests: record type is the first character.
+     */
+    static class SimpleLayout implements CnabLayout {
+        @Override
+        public Optional<String> matchRecord(CnabLine line) {
+            char c = line.content().charAt(0);
+            return switch (c) {
+                case '1' -> Optional.of("HEADER");
+                case '2' -> Optional.of("SEGMENT");
+                case '3' -> Optional.of("TRAILER");
+                default -> Optional.empty();
+            };
+        }
+
+        @Override
+        public Map<String, String> parse(String recordType, CnabLine line) {
+            return Map.of();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add CNAB parsing package with line, record, reader, validator, and layout interface
- read CNAB files and count headers, segments, and trailers
- add test verifying counts against sample HMLCES file

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68a897c338188331b980763f6722dc6e