### PR TITLE
Implement CNAB 240 writer and remittance DTO

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/cnab/domain/RemessaCredito.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/domain/RemessaCredito.java
@@ -1,0 +1,29 @@
+package br.com.paranabanco.dataprev.cnab.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DTO agregador contendo as informações necessárias para geração
+ * dos arquivos de remessa de crédito em layout CNAB 240.
+ */
+@Data
+@Builder
+public class RemessaCredito {
+
+    /** Registro de header do arquivo. */
+    private Map<String, String> header;
+
+    /** Lista de registros de detalhe (segmentos). */
+    @Builder.Default
+    private List<Map<String, String>> segmentos = new ArrayList<>();
+
+    /** Lista de trailers do arquivo. */
+    @Builder.Default
+    private List<Map<String, String>> trailers = new ArrayList<>();
+}
+

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/write/CnabAssembler.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/write/CnabAssembler.java
@@ -1,0 +1,32 @@
+package br.com.paranabanco.dataprev.cnab.write;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+
+/**
+ * Responsável por montar registros CNAB 240 a partir de um {@link RecordType}
+ * e dos valores informados.
+ */
+public class CnabAssembler {
+
+    /**
+     * Monta uma linha CNAB 240 com base no tipo de registro informado.
+     *
+     * @param type   tipo de registro
+     * @param values valores dos campos
+     * @return linha do arquivo com 240 caracteres
+     */
+    public String assemble(RecordType type, Map<String, String> values) {
+        StringBuilder sb = new StringBuilder(240);
+        for (RecordType.Field field : type.getFields()) {
+            String value = values.getOrDefault(field.name(), "");
+            if (value.length() > field.length()) {
+                value = value.substring(0, field.length());
+            }
+            sb.append(StringUtils.rightPad(value, field.length()));
+        }
+        return StringUtils.rightPad(sb.toString(), 240);
+    }
+}
+

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/write/CnabWriter.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/write/CnabWriter.java
@@ -1,0 +1,43 @@
+package br.com.paranabanco.dataprev.cnab.write;
+
+import br.com.paranabanco.dataprev.cnab.domain.RemessaCredito;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Realiza a gravação de arquivos CNAB 240.
+ */
+public class CnabWriter {
+
+    private final CnabAssembler assembler;
+
+    public CnabWriter(CnabAssembler assembler) {
+        this.assembler = assembler;
+    }
+
+    /**
+     * Escreve o conteúdo da {@link RemessaCredito} no caminho informado
+     * utilizando o charset US_ASCII.
+     */
+    public void write(RemessaCredito remessa, Path path) throws IOException {
+        try (var writer = Files.newBufferedWriter(path, StandardCharsets.US_ASCII)) {
+            if (remessa.getHeader() != null) {
+                writer.write(assembler.assemble(RecordType.HEADER, remessa.getHeader()));
+                writer.newLine();
+            }
+            for (Map<String, String> segmento : remessa.getSegmentos()) {
+                writer.write(assembler.assemble(RecordType.SEGMENT, segmento));
+                writer.newLine();
+            }
+            for (Map<String, String> trailer : remessa.getTrailers()) {
+                writer.write(assembler.assemble(RecordType.TRAILER, trailer));
+                writer.newLine();
+            }
+        }
+    }
+}
+

--- a/src/main/java/br/com/paranabanco/dataprev/cnab/write/RecordType.java
+++ b/src/main/java/br/com/paranabanco/dataprev/cnab/write/RecordType.java
@@ -1,0 +1,30 @@
+package br.com.paranabanco.dataprev.cnab.write;
+
+import java.util.List;
+
+/**
+ * Representa os diferentes tipos de registros no layout CNAB 240.
+ */
+public enum RecordType {
+    HEADER(new Field("tipo", 1), new Field("filler", 239)),
+    SEGMENT(new Field("tipo", 1), new Field("valor", 10), new Field("filler", 229)),
+    TRAILER(new Field("tipo", 1), new Field("quantidade", 6), new Field("valorTotal", 10), new Field("filler", 223));
+
+    private final List<Field> fields;
+
+    RecordType(Field... fields) {
+        this.fields = List.of(fields);
+    }
+
+    public List<Field> getFields() {
+        return fields;
+    }
+
+    /**
+     * Definição de campo de um registro.
+     * @param name   nome do campo para identificar no mapa de valores
+     * @param length tamanho fixo do campo
+     */
+    public record Field(String name, int length) { }
+}
+

--- a/src/test/java/br/com/paranabanco/dataprev/cnab/write/CnabWriterTest.java
+++ b/src/test/java/br/com/paranabanco/dataprev/cnab/write/CnabWriterTest.java
@@ -1,0 +1,57 @@
+package br.com.paranabanco.dataprev.cnab.write;
+
+import br.com.paranabanco.dataprev.cnab.domain.RemessaCredito;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CnabWriterTest {
+
+    @Test
+    void geraArquivoComTraillerCorreto() throws Exception {
+        CnabAssembler assembler = new CnabAssembler();
+        CnabWriter writer = new CnabWriter(assembler);
+
+        List<Map<String, String>> segmentos = List.of(
+                Map.of("tipo", "1", "valor", "100"),
+                Map.of("tipo", "1", "valor", "200")
+        );
+
+        int total = segmentos.stream().mapToInt(s -> Integer.parseInt(s.get("valor"))).sum();
+        int count = segmentos.size();
+
+        Map<String, String> trailer = Map.of(
+                "tipo", "9",
+                "quantidade", String.valueOf(count),
+                "valorTotal", String.valueOf(total)
+        );
+
+        RemessaCredito remessa = RemessaCredito.builder()
+                .header(Map.of("tipo", "0"))
+                .segmentos(segmentos)
+                .trailers(List.of(trailer))
+                .build();
+
+        Path tempFile = Files.createTempFile("cnab", ".txt");
+        writer.write(remessa, tempFile);
+
+        List<String> lines = Files.readAllLines(tempFile, StandardCharsets.US_ASCII);
+        assertEquals(1 + segmentos.size() + 1, lines.size());
+        for (String line : lines) {
+            assertEquals(240, line.length());
+        }
+
+        String trailerLine = lines.get(lines.size() - 1);
+        int qtd = Integer.parseInt(trailerLine.substring(1, 7).trim());
+        int valorTotal = Integer.parseInt(trailerLine.substring(7, 17).trim());
+        assertEquals(count, qtd);
+        assertEquals(total, valorTotal);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RemessaCredito DTO to aggregate header, segments and trailers
- introduce CNAB assembler and writer for 240-character records
- include unit test validating record length and trailer totals

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68a897c1b79c833190961d190ba81bf6