### PR TITLE
Use OutputPathResolver for CNAB writer output directory

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/utils/BatchConfig.java
+++ b/src/main/java/br/com/paranabanco/dataprev/utils/BatchConfig.java
@@ -84,17 +84,17 @@ public class BatchConfig  {
 
     @Bean
     @Qualifier("cnabWriter")
-    public CnabItemWriter writer(@Qualifier("positionalFormatter") PositionalFormatter formatter) {
-        // Resolve o diretório de saída e nome do arquivo a partir do YAML
+    public CnabItemWriter writer(@Qualifier("positionalFormatter") PositionalFormatter formatter,
+                                 OutputPathResolver resolver) {
         Path outDir = (props.getOutputDir() == null || props.getOutputDir().isBlank())
-                ? Paths.get("src/main/resources/generated")
+                ? null
                 : Paths.get(props.getOutputDir());
 
         String outName = (props.getOutputName() == null || props.getOutputName().isBlank())
-                ? "HMLCES18.B254.D0000001.txt"
+                ? null
                 : props.getOutputName();
 
-        return new CnabItemWriter(outDir, outName, formatter);
+        return new CnabItemWriter(outDir, outName, formatter, resolver);
     }
 
     private static Charset charsetOf(Charset cs) {

--- a/src/main/java/br/com/paranabanco/dataprev/utils/CnabItemWriter.java
+++ b/src/main/java/br/com/paranabanco/dataprev/utils/CnabItemWriter.java
@@ -16,19 +16,27 @@ public class CnabItemWriter implements ItemStreamWriter<String> {
     private final Path outputDir;
     private final String outputName;
     private final PositionalFormatter formatter;
+    private final OutputPathResolver resolver;
     private BufferedWriter writer;
 
-    public CnabItemWriter(Path outputDir, String outputName, PositionalFormatter formatter) {
+    public CnabItemWriter(Path outputDir, String outputName, PositionalFormatter formatter,
+                          OutputPathResolver resolver) {
         this.outputDir = outputDir;
         this.outputName = outputName;
         this.formatter = formatter;
+        this.resolver = resolver;
     }
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
         try {
-            Path dir = resolveWritableResourcesDir(outputDir);
-            Files.createDirectories(dir);
+            Path dir;
+            if (outputDir != null) {
+                dir = outputDir;
+                Files.createDirectories(dir);
+            } else {
+                dir = resolver.resolveBaseDir();
+            }
 
             String fileName = (outputName == null || outputName.isBlank())
                     ? defaultName()
@@ -53,12 +61,6 @@ public class CnabItemWriter implements ItemStreamWriter<String> {
         if (writer != null) {
             try { writer.close(); } catch (IOException ignored) {}
         }
-    }
-
-    private static Path resolveWritableResourcesDir(Path configured) {
-        if (configured != null) return configured;
-        // padrão: src/main/resources/generated
-        return Paths.get("src", "main", "resources", "generated");
     }
 
     private static String defaultName() {

--- a/src/main/resources/generated/.gitignore
+++ b/src/main/resources/generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- inject `OutputPathResolver` into `CnabItemWriter` and use it to resolve the base output directory
- adjust `BatchConfig` to supply resolver and defer defaults to writer
- version `src/main/resources/generated` with local `.gitignore`

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8cffe0808331a9a1fed7dc3e6731