### PR TITLE
Remove redundant components and fix reader bean naming

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/utils/BatchConfig.java
+++ b/src/main/java/br/com/paranabanco/dataprev/utils/BatchConfig.java
@@ -58,9 +58,8 @@ public class BatchConfig  {
         return new CnabLineMapper();
     }
 
-    @Bean
-    @Qualifier("cnabReader")
-    public FlatFileItemReader<CnabRecord> reader(@Qualifier("cnabLineMapper") CnabLineMapper cnabLineMapper) {
+    @Bean(name = "cnabReader")
+    public FlatFileItemReader<CnabRecord> cnabReader(@Qualifier("cnabLineMapper") CnabLineMapper cnabLineMapper) {
         FlatFileItemReader<CnabRecord> r = new FlatFileItemReader<>();
         r.setResource(props.getFile());
         r.setEncoding(charsetOf(props.getCharset()).name());

--- a/src/main/java/br/com/paranabanco/dataprev/utils/CnabLineMapper.java
+++ b/src/main/java/br/com/paranabanco/dataprev/utils/CnabLineMapper.java
@@ -4,12 +4,10 @@ import org.springframework.batch.item.file.LineMapper;
 import org.springframework.batch.item.file.transform.FieldSet;
 import org.springframework.batch.item.file.transform.FixedLengthTokenizer;
 import org.springframework.batch.item.file.transform.Range;
-import org.springframework.stereotype.Component;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Component
 public class CnabLineMapper implements LineMapper<CnabRecord> {
     private final FixedLengthTokenizer tk240;
     private final FixedLengthTokenizer tk480;

--- a/src/main/java/br/com/paranabanco/dataprev/utils/PositionalFormatter.java
+++ b/src/main/java/br/com/paranabanco/dataprev/utils/PositionalFormatter.java
@@ -1,12 +1,10 @@
 package br.com.paranabanco.dataprev.utils;
 
-import org.springframework.stereotype.Component;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 
-@Component
 public final class PositionalFormatter {
 
     private final CnabLineMapper cnabLineMapper;


### PR DESCRIPTION
## Summary
- Remove `@Component` annotations from `CnabLineMapper` and `PositionalFormatter`
- Name the `FlatFileItemReader` bean `cnabReader` to avoid conflict with existing `Reader` service

## Testing
- `gradle test`
- `gradle bootRun --args='--spring.main.web-application-type=none --spring.batch.job.enabled=false' | grep -m 1 'Started DataprevApplication'`


------
https://chatgpt.com/codex/tasks/task_e_68ac8cfd8eb483319b9d30b3a029b5de