### PR TITLE
feat: restrict test runners to dev profile

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/job/JobRunner.java
+++ b/src/main/java/br/com/paranabanco/dataprev/job/JobRunner.java
@@ -4,10 +4,12 @@ import br.com.paranabanco.dataprev.service.CreditoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Log
 @RequiredArgsConstructor
+@Profile("dev")
 @Component
 public class JobRunner implements CommandLineRunner {
 

--- a/src/main/java/br/com/paranabanco/dataprev/utils/ReaderTest.java
+++ b/src/main/java/br/com/paranabanco/dataprev/utils/ReaderTest.java
@@ -2,12 +2,14 @@ package br.com.paranabanco.dataprev.utils;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import br.com.paranabanco.dataprev.domain.LinhaDoArquivo;
 
 import java.util.List;
 
+@Profile("dev")
 @Component
 public class ReaderTest implements CommandLineRunner {
 
@@ -27,7 +29,7 @@ public class ReaderTest implements CommandLineRunner {
         } catch (Exception e) {
             System.err.println("Erro ao ler o arquivo: " + e.getMessage());
         }
-        
+
         System.out.println("--- LEITURA FINALIZADA ---");
     }
 }


### PR DESCRIPTION
## Summary
- limit `JobRunner` to development profile with `@Profile("dev")`
- limit test helper `ReaderTest` to development profile and tidy structure

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68ac92e52a5883318407ba7a6b47a52e