### PR TITLE
Annotate baseOpenAPI bean in OpenApiConfig

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/config/OpenApiConfig.java
+++ b/src/main/java/br/com/paranabanco/dataprev/config/OpenApiConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
+    @Bean
     OpenAPI baseOpenAPI() {
         return new OpenAPI()
                 .info(new Info()


### PR DESCRIPTION
## Summary
- register the OpenAPI configuration as a bean by annotating `baseOpenAPI()` with `@Bean`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68ac92e2e1808331b48562dbae2e080b