### PR TITLE
Use protected no-args constructors for JPA entities

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/domain/AgenciaINSS.java
+++ b/src/main/java/br/com/paranabanco/dataprev/domain/AgenciaINSS.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "AGENCIA_INSS")
 @Data
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class AgenciaINSS {
     @Id

--- a/src/main/java/br/com/paranabanco/dataprev/domain/Banco.java
+++ b/src/main/java/br/com/paranabanco/dataprev/domain/Banco.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Data
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class Banco {
     @Id

--- a/src/main/java/br/com/paranabanco/dataprev/domain/OrgaoPagador.java
+++ b/src/main/java/br/com/paranabanco/dataprev/domain/OrgaoPagador.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Data
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class OrgaoPagador {
     @Id
@@ -27,3 +27,4 @@ public class OrgaoPagador {
     @JoinColumn(name = "banco_id", nullable = false)
     private Banco banco;
 }
+


### PR DESCRIPTION
## Summary
- replace private no-args constructors with protected ones in Banco, AgenciaINSS and OrgaoPagador entities

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68ac92e2a1448331b9772dc12dad05ca