### PR TITLE
feat: register remessa writer as component

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/config/RemessaCreditoJobConfig.java
+++ b/src/main/java/br/com/paranabanco/dataprev/config/RemessaCreditoJobConfig.java
@@ -1,16 +1,13 @@
 package br.com.paranabanco.dataprev.config;
 
+import br.com.paranabanco.dataprev.job.concessao.RemessaConcessaoWriter;
 import br.com.paranabanco.dataprev.utils.CnabRecord;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.item.Chunk;
-import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemReader;
-import org.springframework.batch.item.ItemWriter;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -19,53 +16,22 @@ import org.springframework.transaction.PlatformTransactionManager;
 public class RemessaCreditoJobConfig {
     @Bean
     public Job gerarArquivoConcessaoJob(JobRepository jobRepository,
-                                        @Qualifier("gerarRemessaConcessaoStep") Step gerarRemessaConcessaoStep) {
+                                        Step gerarRemessaConcessaoStep) {
         return new JobBuilder("gerarArquivoConcessaoJob", jobRepository)
-                .start(gerarRemessaConcessaoStep)   // <- passa o bean Step, sem chamar método
+                .start(gerarRemessaConcessaoStep)
                 .build();
     }
 
     @Bean
-    public Step gerarRemessaConcessaoStep(@Qualifier("dummyCnabReader") ItemReader<CnabRecord> reader,
-                                          @Qualifier("dummyCnabProcessor") ItemProcessor<CnabRecord, CnabRecord> processor,
-                                          @Qualifier("dummyCnabWriter") ItemWriter<CnabRecord> writer,
+    public Step gerarRemessaConcessaoStep(ItemReader<CnabRecord> reader,
+                                          RemessaConcessaoWriter writer,
                                           JobRepository jobRepository,
                                           PlatformTransactionManager tx) {
         return new StepBuilder("gerarRemessaConcessaoStep", jobRepository)
                 .<CnabRecord, CnabRecord>chunk(500, tx)
                 .reader(reader)
-                .processor(processor)
                 .writer(writer)
                 .listener(writer)
                 .build();
-    }
-
-    // Beans dummy para satisfazer as dependências
-    @Bean
-    @Qualifier("dummyCnabReader")
-    public ItemReader<CnabRecord> dummyCnabReader() {
-        return new ItemReader<CnabRecord>() {
-            @Override
-            public CnabRecord read() throws Exception {
-                return null; // Implementação dummy
-            }
-        };
-    }
-
-    @Bean
-    @Qualifier("dummyCnabProcessor")
-    public ItemProcessor<CnabRecord, CnabRecord> dummyCnabProcessor() {
-        return item -> item; // Pass-through
-    }
-
-    @Bean
-    @Qualifier("dummyCnabWriter")
-    public ItemWriter<CnabRecord> dummyCnabWriter() {
-        return new ItemWriter<CnabRecord>() {
-            @Override
-            public void write(Chunk<? extends CnabRecord> chunk) throws Exception {
-                // Implementação dummy - não faz nada
-            }
-        };
     }
 }

--- a/src/main/java/br/com/paranabanco/dataprev/job/concessao/RemessaConcessaoWriter.java
+++ b/src/main/java/br/com/paranabanco/dataprev/job/concessao/RemessaConcessaoWriter.java
@@ -3,7 +3,6 @@ package br.com.paranabanco.dataprev.job.concessao;
 import br.com.paranabanco.dataprev.utils.CnabRecord;
 import br.com.paranabanco.dataprev.utils.OutputPathResolver;
 import br.com.paranabanco.dataprev.utils.PositionalFormatter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,20 +15,13 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
 
+@Component
 public class RemessaConcessaoWriter implements ItemWriter<CnabRecord> {
 
     private final OutputPathResolver outputPathResolver;
     private final PositionalFormatter positionalFormatter;
     private final Charset charset;
     private final String fileName;
-
-    // Construtor padrão necessário para Spring
-    public RemessaConcessaoWriter() {
-        this.outputPathResolver = new OutputPathResolver();
-        this.positionalFormatter = null; // será injetado
-        this.charset = Charset.forName("ISO-8859-1");
-        this.fileName = "FHMLCON16.D0000001.d";
-    }
 
     public RemessaConcessaoWriter(OutputPathResolver outputPathResolver,
                                   PositionalFormatter positionalFormatter,


### PR DESCRIPTION
## Summary
- register RemessaConcessaoWriter as a Spring component
- simplify RemessaCreditoJobConfig to inject the new writer and drop placeholder beans

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68ac92e25f5083318a4b767e8c68456d