### PR TITLE
refine job execution error handling

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/connect/ConnectException.java
+++ b/src/main/java/br/com/paranabanco/dataprev/connect/ConnectException.java
@@ -1,0 +1,14 @@
+package br.com.paranabanco.dataprev.connect;
+
+/**
+ * Exceção para indicar falhas não recuperáveis durante a interação com o CONNECT.
+ */
+public class ConnectException extends RuntimeException {
+    public ConnectException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ConnectException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/paranabanco/dataprev/connect/ConnectService.java
+++ b/src/main/java/br/com/paranabanco/dataprev/connect/ConnectService.java
@@ -6,9 +6,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.batch.core.JobParametersInvalidException;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
@@ -64,21 +68,30 @@ public class ConnectService {
     public Optional<Path> processar(String rotulo) {
         Integer n = ("FHMLCON16".equalsIgnoreCase(rotulo)) ? 6 : null;
         Optional<Path> destino = buscarArquivo(rotulo, n);
-        destino.ifPresent(this::executarJobComArquivo);
+        destino.ifPresent(arquivo -> executarJobComArquivo(arquivo));
         return destino;
     }
 
-    private void executarJobComArquivo(Path arquivo) {
+    private JobExecution executarJobComArquivo(Path arquivo) {
         try {
             JobParameters params = new JobParametersBuilder()
                     .addString("input.file", arquivo.toString())
                     .addLong("run.id", System.currentTimeMillis()) // garante unicidade
                     .toJobParameters();
             log.info("Disparando job cnabJob para arquivo {}", arquivo);
-            jobLauncher.run(cnabJob, params);
+            return jobLauncher.run(cnabJob, params);
+        } catch (JobExecutionAlreadyRunningException e) {
+            log.error("Job já em execução para o arquivo {}", arquivo, e);
+            throw new ConnectException("Job já em execução", e);
+        } catch (JobRestartException e) {
+            log.error("Falha ao reiniciar job para o arquivo {}", arquivo, e);
+            throw new ConnectException("Falha ao reiniciar job", e);
+        } catch (JobParametersInvalidException e) {
+            log.error("Parâmetros inválidos para o arquivo {}", arquivo, e);
+            throw new ConnectException("Parâmetros inválidos para execução do job", e);
         } catch (Exception e) {
             log.error("Falha ao executar job para arquivo {}", arquivo, e);
-            throw new RuntimeException("Falha ao executar job", e);
+            throw new ConnectException("Falha ao executar job", e);
         }
     }
 


### PR DESCRIPTION
## Summary
- return `JobExecution` from job runner to expose execution details
- handle `JobExecutionAlreadyRunningException`, `JobRestartException`, and `JobParametersInvalidException` separately with clear logs
- introduce `ConnectException` to propagate unrecoverable job failures

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68b4ace36c54833197a977713610d30a