### PR TITLE
Validate header and trailer before processing CNAB files

### DIFF
--- a/src/main/java/br/com/paranabanco/dataprev/connect/ConnectService.java
+++ b/src/main/java/br/com/paranabanco/dataprev/connect/ConnectService.java
@@ -66,7 +66,14 @@ public class ConnectService {
     public Optional<Path> processar(String rotulo) {
         Integer n = ("FHMLCON16".equalsIgnoreCase(rotulo)) ? 6 : null;
         Optional<Path> destino = buscarArquivo(rotulo, n);
-        destino.ifPresent(this::executarJobComArquivo);
+        destino.ifPresent(arquivo -> {
+            ValidationResult cabecalhoTrailer = cnabFileValidator.validarHeaderTrailer(arquivo);
+            if (cabecalhoTrailer.isValido()) {
+                executarJobComArquivo(arquivo);
+            } else {
+                log.error("Arquivo {} falhou na validação inicial: {}", arquivo.getFileName(), cabecalhoTrailer.getMensagemFormatada());
+            }
+        });
         return destino;
     }
 
@@ -146,10 +153,17 @@ public class ConnectService {
         if ("SUCESSO".equals(response.status())) {
             try {
                 Path arquivo = Path.of(response.caminhoLocal());
-                
+                log.info("Validando header e trailer do arquivo: {}", response.nomeArquivo());
+                ValidationResult cabecalhoTrailer = cnabFileValidator.validarHeaderTrailer(arquivo);
+                if (!cabecalhoTrailer.isValido()) {
+                    log.error("Arquivo não passou na validação de header/trailer: {}", cabecalhoTrailer.getMensagemFormatada());
+                    return BuscarArquivoResponse.erro(request.rotulo(),
+                        "Arquivo baixado mas falhou na validação de header/trailer: " + cabecalhoTrailer.getMensagemFormatada());
+                }
+
                 log.info("Iniciando validação física do arquivo: {}", response.nomeArquivo());
                 ValidationResult validacao = cnabFileValidator.validarArquivo(arquivo);
-                
+
                 if (validacao.isValido()) {
                     log.info("Arquivo validado com sucesso: {}", validacao.getMensagemFormatada());
                     return BuscarArquivoResponse.sucesso(
@@ -161,10 +175,10 @@ public class ConnectService {
                     );
                 } else {
                     log.error("Arquivo não passou na validação: {}", validacao.getMensagemFormatada());
-                    return BuscarArquivoResponse.erro(request.rotulo(), 
+                    return BuscarArquivoResponse.erro(request.rotulo(),
                         "Arquivo baixado mas falhou na validação: " + validacao.getMensagemFormatada());
                 }
-                
+
             } catch (Exception e) {
                 log.error("Erro ao validar arquivo {}: {}", response.nomeArquivo(), e.getMessage(), e);
                 return BuscarArquivoResponse.erro(request.rotulo(), "Erro na validação: " + e.getMessage());
@@ -183,17 +197,26 @@ public class ConnectService {
         if ("SUCESSO".equals(response.status())) {
             try {
                 Path arquivo = Path.of(response.caminhoLocal());
-                
-                // Validação física do arquivo antes do processamento
+
+                // Validação rápida de header e trailer
+                log.info("Validando header e trailer do arquivo: {}", response.nomeArquivo());
+                ValidationResult cabecalhoTrailer = cnabFileValidator.validarHeaderTrailer(arquivo);
+                if (!cabecalhoTrailer.isValido()) {
+                    log.error("Arquivo não passou na validação de header/trailer: {}", cabecalhoTrailer.getMensagemFormatada());
+                    return BuscarArquivoResponse.erro(request.rotulo(),
+                        "Arquivo baixado mas falhou na validação de header/trailer: " + cabecalhoTrailer.getMensagemFormatada());
+                }
+
+                // Validação física completa do arquivo antes do processamento
                 log.info("Iniciando validação física do arquivo: {}", response.nomeArquivo());
                 ValidationResult validacao = cnabFileValidator.validarArquivo(arquivo);
-                
+
                 if (!validacao.isValido()) {
                     log.error("Arquivo não passou na validação física: {}", validacao.getMensagemFormatada());
-                    return BuscarArquivoResponse.erro(request.rotulo(), 
+                    return BuscarArquivoResponse.erro(request.rotulo(),
                         "Arquivo baixado mas falhou na validação física: " + validacao.getMensagemFormatada());
                 }
-                
+
                 log.info("Arquivo passou na validação física: {}", validacao.getMensagemFormatada());
                 
                 // Executa job específico baseado no tipo de rótulo

--- a/src/main/java/br/com/paranabanco/dataprev/validation/CnabFileValidator.java
+++ b/src/main/java/br/com/paranabanco/dataprev/validation/CnabFileValidator.java
@@ -4,6 +4,7 @@ import br.com.paranabanco.dataprev.enumeration.TipoRotulo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,8 +21,48 @@ public class CnabFileValidator {
     // Constantes de validação
     private static final int TAMANHO_REGISTRO_ESPERADO = 480;
     private static final int FATOR_BLOCO_ESPERADO = 39;
-    
 
+
+
+    /**
+     * Valida apenas o header e o trailer de um arquivo CNAB.
+     * Lê somente a primeira e a última linha para evitar processamento desnecessário
+     * quando esses registros estiverem incorretos.
+     */
+    public ValidationResult validarHeaderTrailer(Path arquivo) {
+        try (BufferedReader reader = Files.newBufferedReader(arquivo)) {
+            String primeiraLinha = reader.readLine();
+            if (primeiraLinha == null || primeiraLinha.length() < 8) {
+                return ValidationResult.erro("Header de arquivo inexistente ou inválido");
+            }
+
+            if (!"0000000".equals(primeiraLinha.substring(0, 7)) ||
+                !"0".equals(primeiraLinha.substring(7, 8))) {
+                return ValidationResult.erro("Header de arquivo inválido");
+            }
+
+            String linha;
+            String ultimaLinha = null;
+            while ((linha = reader.readLine()) != null) {
+                if (linha != null && !linha.trim().isEmpty()) {
+                    ultimaLinha = linha;
+                }
+            }
+
+            if (ultimaLinha == null || ultimaLinha.length() < 8) {
+                return ValidationResult.erro("Trailer de arquivo inexistente ou inválido");
+            }
+
+            if (!"0000000".equals(ultimaLinha.substring(0, 7)) ||
+                !"9".equals(ultimaLinha.substring(7, 8))) {
+                return ValidationResult.erro("Trailer de arquivo inválido");
+            }
+
+            return ValidationResult.sucesso("Header e trailer válidos");
+        } catch (IOException e) {
+            return ValidationResult.erro("Erro ao validar header/trailer: " + e.getMessage());
+        }
+    }
 
     /**
      * Valida um arquivo CNAB completo


### PR DESCRIPTION
## Summary
- Add `validarHeaderTrailer` to check only first and last lines of CNAB files
- Abort processing in `ConnectService` when header or trailer is invalid

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fb4d8e688331829624b8458837c1